### PR TITLE
Add: Template support

### DIFF
--- a/dist/plex-meets-homeassistant.js
+++ b/dist/plex-meets-homeassistant.js
@@ -19882,7 +19882,7 @@ class PlayController {
         };
         this.exportEntity = (entityID, key) => {
             const entities = [];
-            if (lodash.isEqual(key, 'inputSelect')) {
+            if (lodash.isEqual(key, 'inputSelect') || lodash.isEqual(key, 'inputText')) {
                 // special processing for templates
                 if (lodash.isArray(entityID)) {
                     for (let i = 0; i < entityID.length; i += 1) {
@@ -20031,7 +20031,7 @@ class PlayController {
             }
             // get values for template entities
             for (const [key, value] of Object.entries(this.entity)) {
-                if (lodash.isEqual(key, 'inputSelect')) {
+                if (lodash.isEqual(key, 'inputSelect') || lodash.isEqual(key, 'inputText')) {
                     const entities = this.exportEntity(value, key);
                     for (const entity of entities) {
                         if (!lodash.isNil(this.hass.states[entity.value])) {
@@ -20350,7 +20350,8 @@ class PlexMeetsHomeAssistantEditor extends HTMLElement {
                         if (lodash.isEqual(entityRegistry.platform, 'cast') ||
                             lodash.isEqual(entityRegistry.platform, 'kodi') ||
                             lodash.isEqual(entityRegistry.platform, 'androidtv') ||
-                            lodash.isEqual(entityRegistry.platform, 'input_select')) {
+                            lodash.isEqual(entityRegistry.platform, 'input_select') ||
+                            lodash.isEqual(entityRegistry.platform, 'input_text')) {
                             const entityName = `${entityRegistry.platform} | ${entityRegistry.entity_id}`;
                             entities.appendChild(addDropdownItem(entityName));
                             addedEntityStrings.push(entityName);
@@ -21918,12 +21919,9 @@ class PlexMeetsHomeAssistant extends HTMLElement {
                 }
                 else if (lodash.startsWith(entityString, 'androidtv | ') ||
                     lodash.startsWith(entityString, 'kodi | ') ||
-                    lodash.startsWith(entityString, 'cast | ')) {
-                    // eslint-disable-next-line prefer-destructuring
-                    realEntityString = entityString.split(' | ')[1];
-                    isPlexPlayer = false;
-                }
-                else if (lodash.startsWith(entityString, 'input_select | ')) {
+                    lodash.startsWith(entityString, 'cast | ') ||
+                    lodash.startsWith(entityString, 'input_select | ') ||
+                    lodash.startsWith(entityString, 'input_text | ')) {
                     // eslint-disable-next-line prefer-destructuring
                     realEntityString = entityString.split(' | ')[1];
                     isPlexPlayer = false;
@@ -21966,6 +21964,13 @@ class PlexMeetsHomeAssistant extends HTMLElement {
                                         entityObj.inputSelect = [];
                                     }
                                     entityObj.inputSelect.push(entityInRegister.entity_id);
+                                    break;
+                                case 'input_text':
+                                    if (lodash.isNil(entityObj.inputText)) {
+                                        // eslint-disable-next-line no-param-reassign
+                                        entityObj.inputText = [];
+                                    }
+                                    entityObj.inputText.push(entityInRegister.entity_id);
                                     break;
                                 // pass
                             }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -279,7 +279,8 @@ class PlexMeetsHomeAssistantEditor extends HTMLElement {
 						_.isEqual(entityRegistry.platform, 'cast') ||
 						_.isEqual(entityRegistry.platform, 'kodi') ||
 						_.isEqual(entityRegistry.platform, 'androidtv') ||
-						_.isEqual(entityRegistry.platform, 'input_select')
+						_.isEqual(entityRegistry.platform, 'input_select') ||
+						_.isEqual(entityRegistry.platform, 'input_text')
 					) {
 						const entityName = `${entityRegistry.platform} | ${entityRegistry.entity_id}`;
 						entities.appendChild(addDropdownItem(entityName));

--- a/src/modules/PlayController.ts
+++ b/src/modules/PlayController.ts
@@ -587,7 +587,7 @@ class PlayController {
 
 	private exportEntity = (entityID: Array<any> | string, key: string): Array<Record<string, any>> => {
 		const entities: Array<Record<string, any>> = [];
-		if (_.isEqual(key, 'inputSelect')) {
+		if (_.isEqual(key, 'inputSelect') || _.isEqual(key, 'inputText')) {
 			// special processing for templates
 			if (_.isArray(entityID)) {
 				for (let i = 0; i < entityID.length; i += 1) {
@@ -750,7 +750,7 @@ class PlayController {
 
 		// get values for template entities
 		for (const [key, value] of Object.entries(this.entity)) {
-			if (_.isEqual(key, 'inputSelect')) {
+			if (_.isEqual(key, 'inputSelect') || _.isEqual(key, 'inputText')) {
 				const entities = this.exportEntity(value, key);
 				for (const entity of entities) {
 					if (!_.isNil(this.hass.states[entity.value])) {

--- a/src/plex-meets-homeassistant.ts
+++ b/src/plex-meets-homeassistant.ts
@@ -290,12 +290,10 @@ class PlexMeetsHomeAssistant extends HTMLElement {
 			} else if (
 				_.startsWith(entityString, 'androidtv | ') ||
 				_.startsWith(entityString, 'kodi | ') ||
-				_.startsWith(entityString, 'cast | ')
+				_.startsWith(entityString, 'cast | ') ||
+				_.startsWith(entityString, 'input_select | ') ||
+				_.startsWith(entityString, 'input_text | ')
 			) {
-				// eslint-disable-next-line prefer-destructuring
-				realEntityString = entityString.split(' | ')[1];
-				isPlexPlayer = false;
-			} else if (_.startsWith(entityString, 'input_select | ')) {
 				// eslint-disable-next-line prefer-destructuring
 				realEntityString = entityString.split(' | ')[1];
 				isPlexPlayer = false;
@@ -337,6 +335,13 @@ class PlexMeetsHomeAssistant extends HTMLElement {
 									entityObj.inputSelect = [];
 								}
 								entityObj.inputSelect.push(entityInRegister.entity_id);
+								break;
+							case 'input_text':
+								if (_.isNil(entityObj.inputText)) {
+									// eslint-disable-next-line no-param-reassign
+									entityObj.inputText = [];
+								}
+								entityObj.inputText.push(entityInRegister.entity_id);
 								break;
 							default:
 							// pass


### PR DESCRIPTION
# New Features

You can now use `input_select` and `input_text` entities in the card. Value of these cards will be automatically processed and checked for availability. 

Some use cases:
- You can now have input_select with all your media players. Simply select the media player you wish to use and it will be automatically picked up in the card. 
- You can now have automations with room presence. If you are in living room, put living room media player into input_text / input_select. Bedroom? Use bedroom automatically. Combined with Restricted views per user accounts, you can have this seamlessly working on unlimited number of devices.

You can still use all of these in multiples just like before. First available entity will always be chosen.